### PR TITLE
Add DOCKER-ISOLATION chain, adjust to new Docker JSON

### DIFF
--- a/src/ferment/templates.py
+++ b/src/ferment/templates.py
@@ -22,7 +22,10 @@ domain ip {
     }
     table filter {
         chain DOCKER;
+        chain DOCKER-ISOLATION;
         chain FORWARD {
+            jump DOCKER-ISOLATION;
+
             outerface @interface {
                 jump DOCKER;
                 mod conntrack ctstate (RELATED ESTABLISHED) ACCEPT;
@@ -31,6 +34,9 @@ domain ip {
                 outerface ! @interface ACCEPT;
                 outerface @interface ACCEPT;
             }
+        }
+        chain DOCKER-ISOLATION {
+            jump RETURN;
         }
     }
 

--- a/src/ferment/templates.py
+++ b/src/ferment/templates.py
@@ -44,7 +44,10 @@ domain ip {
     @for container in containers:
     # @container['Id']
     @(
-        ip_address = container['NetworkSettings']['IPAddress']
+        networks = container['NetworkSettings']['Networks'].keys()
+        first_network = list(networks)[0]
+        # TODO: Loop over each network instad just using the first network!
+        ip_address = container['NetworkSettings']['Networks'][first_network]['IPAddress']
         port_bindings = container['HostConfig']['PortBindings']
 
         # group into proto:port:(host:port)


### PR DESCRIPTION
Add DOCKER-ISOLATION chain to ferm template (and to iptables), 
the chain has been introduced with recent Docker for improved container isolation and 
is required for proper container startup.

Also the Docker JSON seems to have changed, NetworkSettings has a Networks key now with each network, even if there is only one network used, in this PR the first network is used, ideally one would iterate over all these networks.